### PR TITLE
v0.3.1 Bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ next versioned release, change this header to `## [X.Y.Z] — YYYY-MM-DD`
 and create a fresh empty `## [Unreleased]` block above it.
 -->
 
+## [0.3.1] — 2026-05-17
+
+### Fixed
+
+- **Firearm detail page crash on first load.** The page rendered a blank shell on every visit due to a React Rules of Hooks violation: the `document.title`-setting `useEffect` was placed after three conditional early returns (invalid ID, error, loading). React detected a hook count mismatch between the loading render and the data-arrival render and unmounted the entire tree. The effect is now declared unconditionally at the top of the component with an `if (!firearm) return` guard inside its body.
+
 ### Coming Next
 
 The following items were deliberately scoped out of v0.3.0 and remain

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@
 
 ## Build Status
 
-Current release target: v0.3.0 (firearms + range sessions; tag from main once dev → main lands)
+Current release target: v0.3.1 (bugfix — firearm detail page crash)
 Last shipped public release: v0.2.3 (2026-05-09)
 
 > **Migration history starts at v0.1.9.** Migrations 0001–0022 were squashed into a single `0001_initial_schema.py` before the first public release. The originals are archived in `backend/migrations/archive/` for reference only — they are not part of the active migration chain. New migrations from v0.1.9 forward build incrementally on top of the squashed schema.

--- a/frontend/src/pages/firearms/FirearmDetailPage.tsx
+++ b/frontend/src/pages/firearms/FirearmDetailPage.tsx
@@ -425,6 +425,15 @@ export default function FirearmDetailPage() {
     },
   })
 
+  // Set document.title to the firearm label when loaded; restore on unmount.
+  // MUST live at top-level with other hooks — placement after early returns
+  // is a Rules of Hooks violation that crashes the page on first data arrival.
+  useEffect(() => {
+    if (!firearm) return
+    document.title = `${firearmLabel(firearm)} · AmmoLedger`
+    return () => { document.title = 'AmmoLedger' }
+  }, [firearm])
+
   if (isNaN(firearmId)) {
     return (
       <AppShell>
@@ -473,10 +482,6 @@ export default function FirearmDetailPage() {
   const { primary: heroTitle, contextSuffix: heroSub } = firearmLabelParts(firearm)
   const lastCleaned = firearm.last_cleaned_at ? parseISO(firearm.last_cleaned_at) : null
 
-  useEffect(() => {
-    document.title = `${firearmLabel(firearm)} · AmmoLedger`
-    return () => { document.title = 'AmmoLedger' }
-  }, [firearm])
   const isCleaningHighlighted = firearm.cleaning_status !== 'ok'
   const cleaningHighlight: 'amber' | 'red' | null =
     firearm.cleaning_status === 'overdue'


### PR DESCRIPTION
Fixed
Firearm detail page crash on first load. The page rendered a blank shell on every visit due to a React Rules of Hooks violation: the document.title-setting useEffect was placed after three conditional early returns (invalid ID, error, loading). React detected a hook count mismatch between the loading render and the data-arrival render and unmounted the entire tree. The effect is now declared unconditionally at the top of the component with an if (!firearm) return guard inside its body.