### PR TITLE
v0.3.2 Bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ next versioned release, change this header to `## [X.Y.Z] — YYYY-MM-DD`
 and create a fresh empty `## [Unreleased]` block above it.
 -->
 
+## [0.3.2] — 2026-05-17
+
+### Fixed
+
+- **Firearms list view photo cell now shows the full image.** The 36×36 thumbnail was cropping landscape firearm photos via `object-cover`, showing only a slice of the rail or handguard instead of the firearm itself. The cell now uses `object-contain` so the entire photo fits inside the cell with black letterbox/pillarbox bars as needed. Cell background changed to black so the bars look intentional. Loading skeleton shade bumped one step for visibility against zebra-striped rows.
+
 ## [0.3.1] — 2026-05-17
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,8 @@
 
 ## Build Status
 
-Current release target: v0.3.1 (bugfix — firearm detail page crash)
-Last shipped public release: v0.2.3 (2026-05-09)
+Current release target: v0.3.2 (bugfix — firearms list view photo cell)
+Last shipped public release: v0.3.1 (2026-05-17)
 
 > **Migration history starts at v0.1.9.** Migrations 0001–0022 were squashed into a single `0001_initial_schema.py` before the first public release. The originals are archived in `backend/migrations/archive/` for reference only — they are not part of the active migration chain. New migrations from v0.1.9 forward build incrementally on top of the squashed schema.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <div align="center">
 
 ![License](https://img.shields.io/badge/license-MIT-blue)
-![Version](https://img.shields.io/badge/version-0.3.0-gold)
+![Version](https://img.shields.io/badge/version-0.3.2-gold)
 ![Docker](https://img.shields.io/badge/docker-ready-blue)
 ![PRD](https://img.shields.io/badge/docs-PRD-navy)
 
@@ -14,11 +14,13 @@
 
 # AmmoLedger
 
-> ### 🆕 New in v0.3.0 — Firearms & Range Sessions
+> ### 🆕 New in v0.3.0–v0.3.2 — Firearms & Range Sessions
 >
 > Track your firearms and range trips alongside your ammo. The new **Firearms** page registers each gun with manufacturer, model, caliber, serial, compliance tags, and personal tags. The new **Range** page logs multi-line range days that deduct rounds from ammo boxes and bump per-firearm round counters atomically — and reverse cleanly if you edit or delete a session. **Firearm maintenance log** with cleaning, service, and note events drives a green/amber/red cleaning-status indicator on every firearm and a dedicated dashboard widget for firearms needing service.
 >
 > **Tip:** firearms and range sessions follow the same ownership model as ammo boxes — members own private records by default; admins can mark items shared so everyone on the install can see them. Read-only users see shared items only.
+>
+> **v0.3.1:** fixed a firearm detail page crash on first load (React hook order violation). **v0.3.2:** fixed landscape photo cropping in the firearms list view thumbnail cell.
 
 A self-hosted web application to track your ammunition inventory, firearms, and range sessions. Keep your counts accurate on and off the range.
 

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "0.3.0"
+__version__ = "0.3.2"
 
 
 def get_display_version() -> str:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ammoledger-frontend",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ammoledger-frontend",
-      "version": "0.3.0",
+      "version": "0.3.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ammoledger-frontend",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/pages/firearms/FirearmsListPage.tsx
+++ b/frontend/src/pages/firearms/FirearmsListPage.tsx
@@ -590,7 +590,7 @@ export default function FirearmsListPage() {
                   {Array.from({ length: 5 }).map((_, i) => (
                     <tr key={i} className="border-b border-gray-100 dark:border-gray-800 last:border-0">
                       <td className="px-2 py-2">
-                        <div className="w-9 h-9 animate-pulse bg-gray-200 dark:bg-gray-800 rounded" />
+                        <div className="w-9 h-9 animate-pulse bg-gray-300 dark:bg-gray-700 rounded" />
                       </td>
                       <td className="px-4 py-3">
                         <div className="h-4 animate-pulse bg-gray-200 dark:bg-gray-800 rounded w-48" />
@@ -679,12 +679,12 @@ export default function FirearmsListPage() {
                     onClick={() => navigate(`/firearms/${f.id}`)}
                   >
                     <td className="px-2 py-2">
-                      <div className="w-9 h-9 rounded bg-gray-100 dark:bg-gray-800 overflow-hidden flex items-center justify-center">
+                      <div className="w-9 h-9 rounded bg-black overflow-hidden flex items-center justify-center">
                         {f.default_photo_thumb_url ? (
                           <img
                             src={photoSrc(f.default_photo_thumb_url)}
                             alt=""
-                            className="w-full h-full object-cover"
+                            className="w-full h-full object-contain"
                           />
                         ) : (
                           <FirearmIcon className="w-4 h-4 text-gray-400" />


### PR DESCRIPTION
## [0.3.2] — 2026-05-17

### Fixed

- **Firearms list view photo cell now shows the full image.** The 36×36 thumbnail was cropping landscape firearm photos via `object-cover`, showing only a slice of the rail or handguard instead of the firearm itself. The cell now uses `object-contain` so the entire photo fits inside the cell with black letterbox/pillarbox bars as needed. Cell background changed to black so the bars look intentional. Loading skeleton shade bumped one step for visibility against zebra-striped rows.
